### PR TITLE
Update zepben auth

### DIFF
--- a/src/zepben/eas/client/eas_client.py
+++ b/src/zepben/eas/client/eas_client.py
@@ -74,6 +74,11 @@ class EasClient:
                     'client_id': client_id,
                     'scope': 'trusted' if self.__authenticator.auth_method is AuthMethod.SELF else 'offline_access openid profile email0'
                 })
+                self.__authenticator.refresh_request_data.update({
+                    "grant_type": "refresh_token",
+                    'client_id': client_id,
+                    'scope': 'trusted' if self.__authenticator.auth_method is AuthMethod.SELF else 'offline_access openid profile email0'
+                })
                 if username is not None and password is not None:
                     self.__authenticator.token_request_data.update({
                         'grant_type': 'password',

--- a/src/zepben/eas/client/eas_client.py
+++ b/src/zepben/eas/client/eas_client.py
@@ -34,6 +34,7 @@ class EasClient:
             host: str,
             port: int,
             client_id: str,
+            authenticator: Optional[ZepbenAuthenticator] = None,
             client_secret: Optional[str] = None,
             username: Optional[str] = None,
             password: Optional[str] = None,
@@ -49,44 +50,47 @@ class EasClient:
         self.__host = host
         self.__port = port
         self.__verify_certificate = verify_certificate
-        self.__authenticator = create_authenticator(
-            conf_address=construct_url(
-                protocol="https",
-                host=self.__host,
-                port=self.__port,
-                path="/api/config/auth"
-            ),
-            verify_certificate=self.__verify_certificate,
-            auth_type_field="configType",
-            audience_field="audience",
-            issuer_domain_field="issuerDomain"
-        )
-        if self.__authenticator is not None:
-            if client_id is None:
-                raise ValueError(
-                    "Incompatible arguments passed to connect to secured Evolve App Server. You must specify (client_id) "
-                    "to establish a secure connection with token based auth.")
-            self.__authenticator.token_request_data.update({
-                'client_id': client_id,
-                'scope': 'trusted' if self.__authenticator.auth_method is AuthMethod.SELF else 'offline_access openid profile email0'
-            })
-            if username is not None and password is not None:
+        if authenticator is not None:
+            self.__authenticator = authenticator
+        else:
+            self.__authenticator = create_authenticator(
+                conf_address=construct_url(
+                    protocol="https",
+                    host=self.__host,
+                    port=self.__port,
+                    path="/api/config/auth"
+                ),
+                verify_certificate=self.__verify_certificate,
+                auth_type_field="configType",
+                audience_field="audience",
+                issuer_domain_field="issuerDomain"
+            )
+            if self.__authenticator is not None:
+                if client_id is None:
+                    raise ValueError(
+                        "Incompatible arguments passed to connect to secured Evolve App Server. You must specify (client_id) "
+                        "to establish a secure connection with token based auth.")
                 self.__authenticator.token_request_data.update({
-                    'grant_type': 'password',
-                    'username': username,
-                    'password': sha256(password.encode('utf-8')).hexdigest() if self.__authenticator.auth_method is AuthMethod.SELF else password
+                    'client_id': client_id,
+                    'scope': 'trusted' if self.__authenticator.auth_method is AuthMethod.SELF else 'offline_access openid profile email0'
                 })
-                if client_secret is not None:
-                    self.__authenticator.token_request_data.update({'client_secret': client_secret})
-            elif client_secret is not None:
-                self.__authenticator.token_request_data.update({
-                    'grant_type': 'client_credentials',
-                    'client_secret': client_secret
-                })
-            else:
-                raise ValueError(
-                    "Incompatible arguments passed to connect to secured Evolve App Server. You must specify at least "
-                    "(username, password) or (client_secret) for a secure connection with token based auth.")
+                if username is not None and password is not None:
+                    self.__authenticator.token_request_data.update({
+                        'grant_type': 'password',
+                        'username': username,
+                        'password': sha256(password.encode('utf-8')).hexdigest() if self.__authenticator.auth_method is AuthMethod.SELF else password
+                    })
+                    if client_secret is not None:
+                        self.__authenticator.token_request_data.update({'client_secret': client_secret})
+                elif client_secret is not None:
+                    self.__authenticator.token_request_data.update({
+                        'grant_type': 'client_credentials',
+                        'client_secret': client_secret
+                    })
+                else:
+                    raise ValueError(
+                        "Incompatible arguments passed to connect to secured Evolve App Server. You must specify at least "
+                        "(username, password) or (client_secret) for a secure connection with token based auth.")
 
     def __get_request_headers(self, content_type: str = "application/json") -> dict:
         headers = {"content-type": content_type}

--- a/src/zepben/eas/client/eas_client.py
+++ b/src/zepben/eas/client/eas_client.py
@@ -8,7 +8,7 @@ import warnings
 
 import requests
 from urllib3.exceptions import InsecureRequestWarning
-from zepben.auth.eas.authenticator import EasAuthenticator
+from zepben.eas.client.util import construct_url
 from zepben.eas.client.study import Study
 
 __all__ = ["EasClient"]
@@ -62,7 +62,12 @@ class EasClient:
             if self.__verify_certificate is False:
                 warnings.filterwarnings("ignore", category=InsecureRequestWarning)
             requests.post(
-                "{host}:{port}/api/graphql".format(host=self.__host, port=self.__port),
+                construct_url(
+                    protocol=self.__protocol,
+                    host=self.__host,
+                    port=self.__port,
+                    path="/api/graphql"
+                ),
                 headers=self.__get_request_headers(),
                 json={
                     "query": """

--- a/src/zepben/eas/client/util.py
+++ b/src/zepben/eas/client/util.py
@@ -1,0 +1,16 @@
+#  Copyright 2020 Zeppelin Bend Pty Ltd
+#
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+__all__ = ["construct_url"]
+
+from typing import Union
+
+def construct_url(protocol, host, path, port: Union[str, int] = None) -> str:
+    return f"{protocol}://{host}{f':{port}' if port else ''}{path}"


### PR DESCRIPTION
Refactor client to construct an authenticator from properties, using the new authenticator, rather than being passed in one. Allow a user to directly pass in their own authenticator if they wish. Add that useful construct_url util function.