### PR TITLE
[DEV 2326] Update for hc default load profile

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,11 @@
 * None.
 
 ### New Features
-* None.
+* Update `ModelConfig` to contain four optional list of values which makes up the default load profile for hosting capacity model generation.
+  * `default_load_watts` Note: expects same size list of values as `default_load_var` 
+  * `default_gen_watts` Note: expects same size list of values as `default_gen_var`
+  * `default_load_var`
+  * `default_gen_var`
 
 ### Enhancements
 * None.

--- a/src/zepben/eas/client/eas_client.py
+++ b/src/zepben/eas/client/eas_client.py
@@ -258,6 +258,10 @@ class EasClient:
                                     "energyConsumerMeterGroup": work_package.generator_config.model.meter_placement_config.energy_consumer_meter_group
                                 } if work_package.generator_config.model.meter_placement_config is not None else None,
                                 "seed": work_package.generator_config.model.seed,
+                                "defaultLoadWatts" : work_package.generator_config.model.default_load_watts,
+                                "defaultGenWatts" : work_package.generator_config.model.default_gen_watts,
+                                "defaultLoadVar" : work_package.generator_config.model.default_load_var,
+                                "defaultGenVar" : work_package.generator_config.model.default_gen_var
                             } if work_package.generator_config.model is not None else None,
                             "solve": {
                                 "normVMinPu": work_package.generator_config.solve.norm_vmin_pu,

--- a/src/zepben/eas/client/work_package.py
+++ b/src/zepben/eas/client/work_package.py
@@ -135,10 +135,10 @@ class ModelConfig:
     load_interval_length_hours: Optional[float] = None
     meter_placement_config: Optional[MeterPlacementConfig] = None
     seed: Optional[int] = None
-    default_load_watts: Optional[float] = None
-    default_gen_watts: Optional[float] = None
-    default_load_var: Optional[float] = None
-    default_gen_var: Optional[float] = None
+    default_load_watts: Optional[List[float]] = None
+    default_gen_watts: Optional[List[float]] = None
+    default_load_var: Optional[List[float]] = None
+    default_gen_var: Optional[List[float]] = None
 
 
 class SolveMode(Enum):

--- a/src/zepben/eas/client/work_package.py
+++ b/src/zepben/eas/client/work_package.py
@@ -135,6 +135,10 @@ class ModelConfig:
     load_interval_length_hours: Optional[float] = None
     meter_placement_config: Optional[MeterPlacementConfig] = None
     seed: Optional[int] = None
+    default_load_watts: Optional[float] = None
+    default_gen_watts: Optional[float] = None
+    default_load_var: Optional[float] = None
+    default_gen_var: Optional[float] = None
 
 
 class SolveMode(Enum):


### PR DESCRIPTION
# Description

update work_package and eas_client to incorporate default load profile for hosting capacity studies.
  * `default_load_watts` Note: expects same size list of values as `default_load_var` 
  * `default_gen_watts` Note: expects same size list of values as `default_gen_var`
  * `default_load_var`
  * `default_gen_var`


# Associated tasks

[Corresponding EAS pr](https://github.com/zepben/evolve-app-server/pull/170)

# Test Steps

Attempt to pass in default profile values and generate a model.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

All added variables are optional, this shouldn't be a breaking change.