### PR TITLE
DEV-2625 Add transformer_tap_settings to workpackage request

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 * None.
 
 ### New Features
-* None.
+* Update `ModelConfig` to contain an optional `transformer_tap_settings` field to specify a set of distribution transformer tap settings to be applied by the model-processor.
 
 ### Enhancements
 * Added work package config documentation.

--- a/src/zepben/eas/client/eas_client.py
+++ b/src/zepben/eas/client/eas_client.py
@@ -262,7 +262,8 @@ class EasClient:
                                 "defaultLoadWatts": work_package.generator_config.model.default_load_watts,
                                 "defaultGenWatts": work_package.generator_config.model.default_gen_watts,
                                 "defaultLoadVar": work_package.generator_config.model.default_load_var,
-                                "defaultGenVar": work_package.generator_config.model.default_gen_var
+                                "defaultGenVar": work_package.generator_config.model.default_gen_var,
+                                "transformerTapSettings": work_package.generator_config.model.transformer_tap_settings
                             },
                             "solve": work_package.generator_config.solve and {
                                 "normVMinPu": work_package.generator_config.solve.norm_vmin_pu,

--- a/src/zepben/eas/client/work_package.py
+++ b/src/zepben/eas/client/work_package.py
@@ -353,6 +353,11 @@ class ModelConfig:
         1.0: 24 entries for daily and 8760 for yearly
     """
 
+    transformer_tap_settings: Optional[str] = None
+    """
+    The name of the set of distribution transformer tap settings to be applied to the model from an external source.
+    """
+
 
 class SolveMode(Enum):
     YEARLY = "YEARLY"


### PR DESCRIPTION
# Description

Adds the `transformerTapSettings` field to the workpackage class. This optional field determines what set distribution transformer tap settings are applied from an external source during [opendss]model generation.

# Associated tasks


# Test Steps

Explain in detail how your reviewer can test the changes proposed in this PR. If it cannot be tested, leave an explanation on why.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] ~I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
- [ ] ~I have updated any documentation required for these changes.~ Didn't find any

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

Probably not backwards compatible depending on what tries to deserialise the workpackage grpc message. 
