### PR TITLE
[Dev 3001] Add calibration time support and getCalibrationSets

### DIFF
--- a/src/zepben/eas/client/eas_client.py
+++ b/src/zepben/eas/client/eas_client.py
@@ -748,29 +748,17 @@ class EasClient:
         with warnings.catch_warnings():
             if not self._verify_certificate:
                 warnings.filterwarnings("ignore", category=InsecureRequestWarning)
-            if calibration_time_local is not None:
-                json = {
-                    "query": """
-                        mutation runCalibration($calibrationName: String!, $calibrationTimeLocal: LocalDateTime) {
-                            runCalibration(calibrationName: $calibrationName, calibrationTimeLocal: $calibrationTimeLocal)
-                        }
-                    """,
-                    "variables": {
-                        "calibrationName": calibration_name,
-                        "calibrationTimeLocal": calibration_time_local
+            json = {
+                "query": """
+                    mutation runCalibration($calibrationName: String!, $calibrationTimeLocal: LocalDateTime) {
+                        runCalibration(calibrationName: $calibrationName, calibrationTimeLocal: $calibrationTimeLocal)
                     }
+                """,
+                "variables": {
+                    "calibrationName": calibration_name,
+                    "calibrationTimeLocal": calibration_time_local
                 }
-            else:
-                json = {
-                    "query": """
-                        mutation runCalibration($calibrationName: String!) {
-                            runCalibration(calibrationName: $calibrationName)
-                        }
-                    """,
-                    "variables": {
-                        "calibrationName": calibration_name
-                    }
-                }
+            }
 
             if self._verify_certificate:
                 sslcontext = ssl.create_default_context(cafile=self._ca_filename)

--- a/src/zepben/eas/client/eas_client.py
+++ b/src/zepben/eas/client/eas_client.py
@@ -727,18 +727,22 @@ class EasClient:
                     response = await response.text()
                 return response
 
-    def run_hosting_capacity_calibration(self, calibration_name: str):
+    def run_hosting_capacity_calibration(self, calibration_name: str, local_calibration_time: Optional[str] = None):
         """
         Send request to run hosting capacity calibration
         :param calibration_name: A string representation of the calibration name
+        :param local_calibration_time: A string representation of the calibration time, in model time.
         :return: The HTTP response received from the Evolve App Server after attempting to run the calibration
         """
-        return get_event_loop().run_until_complete(self.async_run_hosting_capacity_calibration(calibration_name))
+        return get_event_loop().run_until_complete(
+            self.async_run_hosting_capacity_calibration(calibration_name, local_calibration_time))
 
-    async def async_run_hosting_capacity_calibration(self, calibration_name: str):
+    async def async_run_hosting_capacity_calibration(self, calibration_name: str,
+                                                     calibration_time: Optional[str] = None):
         """
         Send asynchronous request to run hosting capacity calibration
         :param calibration_name: A string representation of the calibration name
+        :param calibration_time: A string representation of the calibration time, in model time.
         :return: The HTTP response received from the Evolve App Server after attempting to run the calibration
         """
         with warnings.catch_warnings():
@@ -746,12 +750,13 @@ class EasClient:
                 warnings.filterwarnings("ignore", category=InsecureRequestWarning)
             json = {
                 "query": """
-                    mutation runCalibration($calibrationName: String!) {
-                        runCalibration(calibrationName: $calibrationName)
+                    mutation runCalibration($calibrationName: String!, $calibrationTime: LocalDateTime) {
+                        runCalibration(calibrationName: $calibrationName, calibrationTime: $calibrationTime)
                     }
                 """,
                 "variables": {
-                    "calibrationName": calibration_name
+                    "calibrationName": calibration_name,
+                    "calibrationTime": calibration_time
                 }
             }
             if self._verify_certificate:
@@ -772,7 +777,7 @@ class EasClient:
     def get_hosting_capacity_calibration_run(self, id: str):
         """
         Retrieve information of a hosting capacity calibration run
-        :param id: The calibration run ID
+        :param id: The calibration ID
         :return: The HTTP response received from the Evolve App Server after requesting calibration run info
         """
         return get_event_loop().run_until_complete(self.async_get_hosting_capacity_calibration_run(id))
@@ -780,7 +785,7 @@ class EasClient:
     async def async_get_hosting_capacity_calibration_run(self, id: str):
         """
         Retrieve information of a hosting capacity calibration run
-        :param id: The calibration run ID
+        :param id: The calibration ID
         :return: The HTTP response received from the Evolve App Server after requesting calibration run info
         """
         with warnings.catch_warnings():
@@ -789,11 +794,12 @@ class EasClient:
             json = {
                 "query": """
                     query getCalibrationRun($id: ID!) {
-                        getCalibrationRun(calibrationRunId: $id) {
+                        getCalibrationRun(id: $id) {
                             id
                             name
                             workflowId
                             runId
+                            localCalibrationTime
                             startAt
                             completedAt
                             status
@@ -803,6 +809,43 @@ class EasClient:
                 "variables": {
                     "id": id
                 }
+            }
+            if self._verify_certificate:
+                sslcontext = ssl.create_default_context(cafile=self._ca_filename)
+
+            async with self.session.post(
+                    construct_url(protocol=self._protocol, host=self._host, port=self._port, path="/api/graphql"),
+                    headers=self._get_request_headers(),
+                    json=json,
+                    ssl=sslcontext if self._verify_certificate else False
+            ) as response:
+                if response.ok:
+                    response = await response.json()
+                else:
+                    response = await response.text()
+                return response
+
+    def get_hosting_capacity_calibration_sets(self):
+        """
+        Retrieve a list of all completed calibration runs initiated through Evolve App Server
+        :return: The HTTP response received from the Evolve App Server after requesting completed calibration runs
+        """
+        return get_event_loop().run_until_complete(self.async_get_hosting_capacity_calibration_sets())
+
+    async def async_get_hosting_capacity_calibration_sets(self):
+        """
+        Retrieve a list of all completed calibration runs initiated through Evolve App Server
+        :return: The HTTP response received from the Evolve App Server after requesting completed calibration runs
+        """
+        with warnings.catch_warnings():
+            if not self._verify_certificate:
+                warnings.filterwarnings("ignore", category=InsecureRequestWarning)
+            json = {
+                "query": """
+                    query { 
+                    getCalibrationSets
+                     }
+                """
             }
             if self._verify_certificate:
                 sslcontext = ssl.create_default_context(cafile=self._ca_filename)

--- a/test/test_eas_client.py
+++ b/test/test_eas_client.py
@@ -629,7 +629,7 @@ def get_hosting_capacity_run_calibration_request_handler(request):
     actual_body = json.loads(request.data.decode())
     query = " ".join(actual_body['query'].split())
 
-    assert query == "query getCalibrationRun($id: ID!) { getCalibrationRun(id: $id) { id name workflowId runId localCalibrationTime startAt completedAt status } }"
+    assert query == "query getCalibrationRun($id: ID!) { getCalibrationRun(id: $id) { id name workflowId runId calibrationTimeLocal startAt completedAt status } }"
     assert actual_body['variables'] == {"id": "calibration-id"}
 
     return Response(json.dumps({"result": "success"}), status=200, content_type="application/json")

--- a/test/test_eas_client.py
+++ b/test/test_eas_client.py
@@ -679,6 +679,30 @@ def test_get_hosting_capacity_calibration_run_valid_certificate_success(ca: trus
         assert res == {"result": "success"}
 
 
+def hosting_capacity_run_calibration_with_calibration_time_request_handler(request):
+    actual_body = json.loads(request.data.decode())
+    query = " ".join(actual_body['query'].split())
+
+    assert query == "mutation runCalibration($calibrationName: String!, $calibrationTimeLocal: LocalDateTime) { runCalibration(calibrationName: $calibrationName, calibrationTimeLocal: $calibrationTimeLocal) }"
+    assert actual_body['variables'] == {"calibrationName": "TEST CALIBRATION", "calibrationTimeLocal": "1992-01-28T00:00:20"}
+
+    return Response(json.dumps({"result": "success"}), status=200, content_type="application/json")
+
+
+def test_run_hosting_capacity_calibration_with_calibration_time_no_verify_success(httpserver: HTTPServer):
+    eas_client = EasClient(
+        LOCALHOST,
+        httpserver.port,
+        verify_certificate=False
+    )
+
+    httpserver.expect_oneshot_request("/api/graphql").respond_with_handler(
+        hosting_capacity_run_calibration_with_calibration_time_request_handler)
+    res = eas_client.run_hosting_capacity_calibration("TEST CALIBRATION", "1992-01-28T00:00:20")
+    httpserver.check_assertions()
+    assert res == {"result": "success"}
+
+
 def get_hosting_capacity_calibration_sets_request_handler(request):
     actual_body = json.loads(request.data.decode())
     query = " ".join(actual_body['query'].split())

--- a/test/test_eas_client.py
+++ b/test/test_eas_client.py
@@ -575,8 +575,8 @@ def hosting_capacity_run_calibration_request_handler(request):
     actual_body = json.loads(request.data.decode())
     query = " ".join(actual_body['query'].split())
 
-    assert query == "mutation runCalibration($calibrationName: String!) { runCalibration(calibrationName: $calibrationName) }"
-    assert actual_body['variables'] == {"calibrationName": "TEST CALIBRATION"}
+    assert query == "mutation runCalibration($calibrationName: String!, $calibrationTimeLocal: LocalDateTime) { runCalibration(calibrationName: $calibrationName, calibrationTimeLocal: $calibrationTimeLocal) }"
+    assert actual_body['variables'] == {"calibrationName": "TEST CALIBRATION", "calibrationTimeLocal": None}
 
     return Response(json.dumps({"result": "success"}), status=200, content_type="application/json")
 

--- a/test/test_eas_client.py
+++ b/test/test_eas_client.py
@@ -174,7 +174,8 @@ def test_get_work_package_cost_estimation_no_verify_success(httpserver: HTTPServ
         verify_certificate=False
     )
 
-    httpserver.expect_oneshot_request("/api/graphql").respond_with_json({"data": {"getWorkPackageCostEstimation": "123.45"}})
+    httpserver.expect_oneshot_request("/api/graphql").respond_with_json(
+        {"data": {"getWorkPackageCostEstimation": "123.45"}})
     res = eas_client.get_work_package_cost_estimation(
         WorkPackageConfig(
             "wp_name",
@@ -569,14 +570,16 @@ def test_raises_error_if_access_token_and_client_secret_configured(httpserver: H
     assert "Incompatible arguments passed to connect to secured Evolve App Server. You cannot provide multiple types of authentication. When using an access_token, do not provide client_id, client_secret, username, password, or token_fetcher." in str(
         error_message_for_username.value)
 
+
 def hosting_capacity_run_calibration_request_handler(request):
     actual_body = json.loads(request.data.decode())
     query = " ".join(actual_body['query'].split())
 
-    assert  query == "mutation runCalibration($calibrationName: String!) { runCalibration(calibrationName: $calibrationName) }"
+    assert query == "mutation runCalibration($calibrationName: String!) { runCalibration(calibrationName: $calibrationName) }"
     assert actual_body['variables'] == {"calibrationName": "TEST CALIBRATION"}
 
     return Response(json.dumps({"result": "success"}), status=200, content_type="application/json")
+
 
 def test_run_hosting_capacity_calibration_no_verify_success(httpserver: HTTPServer):
     eas_client = EasClient(
@@ -585,7 +588,8 @@ def test_run_hosting_capacity_calibration_no_verify_success(httpserver: HTTPServ
         verify_certificate=False
     )
 
-    httpserver.expect_oneshot_request("/api/graphql").respond_with_handler(hosting_capacity_run_calibration_request_handler)
+    httpserver.expect_oneshot_request("/api/graphql").respond_with_handler(
+        hosting_capacity_run_calibration_request_handler)
     res = eas_client.run_hosting_capacity_calibration("TEST CALIBRATION")
     httpserver.check_assertions()
     assert res == {"result": "success"}
@@ -614,19 +618,22 @@ def test_run_hosting_capacity_calibration_valid_certificate_success(ca: trustme.
             ca_filename=ca_filename
         )
 
-        httpserver.expect_oneshot_request("/api/graphql").respond_with_handler(hosting_capacity_run_calibration_request_handler)
+        httpserver.expect_oneshot_request("/api/graphql").respond_with_handler(
+            hosting_capacity_run_calibration_request_handler)
         res = eas_client.run_hosting_capacity_calibration("TEST CALIBRATION")
         httpserver.check_assertions()
         assert res == {"result": "success"}
+
 
 def get_hosting_capacity_run_calibration_request_handler(request):
     actual_body = json.loads(request.data.decode())
     query = " ".join(actual_body['query'].split())
 
-    assert  query == "query getCalibrationRun($id: ID!) { getCalibrationRun(calibrationRunId: $id) { id name workflowId runId startAt completedAt status } }"
+    assert query == "query getCalibrationRun($id: ID!) { getCalibrationRun(id: $id) { id name workflowId runId localCalibrationTime startAt completedAt status } }"
     assert actual_body['variables'] == {"id": "calibration-id"}
 
     return Response(json.dumps({"result": "success"}), status=200, content_type="application/json")
+
 
 def test_get_hosting_capacity_calibration_run_no_verify_success(httpserver: HTTPServer):
     eas_client = EasClient(
@@ -635,7 +642,8 @@ def test_get_hosting_capacity_calibration_run_no_verify_success(httpserver: HTTP
         verify_certificate=False
     )
 
-    httpserver.expect_oneshot_request("/api/graphql").respond_with_handler(get_hosting_capacity_run_calibration_request_handler)
+    httpserver.expect_oneshot_request("/api/graphql").respond_with_handler(
+        get_hosting_capacity_run_calibration_request_handler)
     res = eas_client.get_hosting_capacity_calibration_run("calibration-id")
     httpserver.check_assertions()
     assert res == {"result": "success"}
@@ -664,7 +672,33 @@ def test_get_hosting_capacity_calibration_run_valid_certificate_success(ca: trus
             ca_filename=ca_filename
         )
 
-        httpserver.expect_oneshot_request("/api/graphql").respond_with_handler(get_hosting_capacity_run_calibration_request_handler)
+        httpserver.expect_oneshot_request("/api/graphql").respond_with_handler(
+            get_hosting_capacity_run_calibration_request_handler)
         res = eas_client.get_hosting_capacity_calibration_run("calibration-id")
         httpserver.check_assertions()
         assert res == {"result": "success"}
+
+
+def get_hosting_capacity_calibration_sets_request_handler(request):
+    actual_body = json.loads(request.data.decode())
+    query = " ".join(actual_body['query'].split())
+
+    assert query == "query { getCalibrationSets }"
+
+    assert "variables" not in actual_body
+
+    return Response(json.dumps(["one", "two", "three"]), status=200, content_type="application/json")
+
+
+def test_get_hosting_capacity_calibration_sets_no_verify_success(httpserver: HTTPServer):
+    eas_client = EasClient(
+        LOCALHOST,
+        httpserver.port,
+        verify_certificate=False
+    )
+
+    httpserver.expect_oneshot_request("/api/graphql").respond_with_handler(
+        get_hosting_capacity_calibration_sets_request_handler)
+    res = eas_client.get_hosting_capacity_calibration_sets()
+    httpserver.check_assertions()
+    assert res == ["one", "two", "three"]


### PR DESCRIPTION
# Description

Add support for providing a calibration time to `run_hosting_capacity_calibration`

Update to match need gql variable name `calibrationRunId` -> `id` .

Add support for `get_hosting_capacity_calibration_run`

# Associated tasks

 - https://github.com/zepben/evolve-app-server/pull/206

# Test Steps

Spin up eas, run some stuff

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [ ] ~I have updated the changelog.~ Initial feature release entry covers this
- [ ] I have updated any documentation required for these changes.

# Breaking Changes
- [ ] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

Not backwards compatible with the last snapshot release but other than that it's new features.