### PR TITLE
[PROJ-6325] remove timezone info from python EAS client and add load overrides to run open-dss export

### DIFF
--- a/src/zepben/eas/client/eas_client.py
+++ b/src/zepben/eas/client/eas_client.py
@@ -986,12 +986,29 @@ class EasClient:
                             },
                             "modulesConfiguration": {
                                 "common": {
-                                    "timeZone": config.time_zone.__str__(),
-                                    **({"fixedTime": config.load_time.time.isoformat()}
-                                       if isinstance(config.load_time, FixedTime) else {}),
+                                    **({ "loadTime": config.load_time.time.isoformat(),
+                                          "overrides": config.load_time.load_overrides and [
+                                               {
+                                                   "loadId": key,
+                                                   "loadWattsOverride": value.load_watts,
+                                                   "genWattsOverride": value.gen_watts,
+                                                   "loadVarOverride": value.load_var,
+                                                   "genVarOverride": value.gen_var,
+                                               } for key, value in config.load_time.load_overrides.items()
+                                           ]
+                                       } if isinstance(config.load_time, FixedTime) else {}),
                                     **({"timePeriod": {
-                                        "start": config.load_time.start_time.isoformat(),
-                                        "end": config.load_time.end_time.isoformat(),
+                                        "startTime": config.load_time.start_time.isoformat(),
+                                        "endTime": config.load_time.end_time.isoformat(),
+                                        "overrides": config.load_time.load_overrides and [
+                                            {
+                                                "loadId": key,
+                                                "loadWattsOverride": value.load_watts,
+                                                "genWattsOverride": value.gen_watts,
+                                                "loadVarOverride": value.load_var,
+                                                "genVarOverride": value.gen_var,
+                                            } for key, value in config.load_time.load_overrides.items()
+                                        ]
                                     }} if isinstance(config.load_time, TimePeriod) else {})
                                 },
                                 **({"generator": {
@@ -1145,9 +1162,26 @@ class EasClient:
                                 }
                                 modulesConfiguration {
                                     common {
+                                        fixedTime{
+                                            loadTime
+                                            overrides {
+                                                loadId
+                                                loadWattsOverride
+                                                genWattsOverride
+                                                loadVarOverride
+                                                genVarOverride
+                                            }
+                                        }
                                         timePeriod {
-                                            start
-                                            end
+                                            startTime
+                                            endTime
+                                            overrides {
+                                                loadId
+                                                loadWattsOverride
+                                                genWattsOverride
+                                                loadVarOverride
+                                                genVarOverride
+                                            }
                                         }
                                     }
                                     generator {

--- a/src/zepben/eas/client/opendss.py
+++ b/src/zepben/eas/client/opendss.py
@@ -25,7 +25,6 @@ class OpenDssConfig:
     scenario: str
     year: int
     feeder: str
-    time_zone: tzinfo
     load_time: Union[TimePeriod, FixedTime]
     generator_config: Optional[GeneratorConfig] = None
     model_name: Optional[str] = None

--- a/test/test_eas_client.py
+++ b/test/test_eas_client.py
@@ -780,10 +780,16 @@ def run_opendss_export_request_handler(request):
                 },
                 "modulesConfiguration": {
                     "common": {
-                        "timeZone": "UTC+10:00",
                         "timePeriod": {
-                            "start": "2022-04-01T00:00:00",
-                            "end": "2023-04-01T00:00:00",
+                            "startTime": "2022-04-01T00:00:00",
+                            "endTime": "2023-04-01T00:00:00",
+                            "overrides": [{
+                                'loadId': 'meter1',
+                                'loadWattsOverride': [1.0],
+                                'genWattsOverride': [2.0],
+                                'loadVarOverride': [3.0],
+                                'genVarOverride': [4.0]
+                            }]
                         }
                     },
                     "generator": {
@@ -879,10 +885,10 @@ OPENDSS_CONFIG = OpenDssConfig(
     scenario="scenario1",
     year=2024,
     feeder="feeder1",
-    time_zone=timezone(timedelta(hours=10)),
     load_time=TimePeriod(
         datetime(2022, 4, 1),
-        datetime(2023, 4, 1)
+        datetime(2023, 4, 1),
+        {"meter1": TimePeriodLoadOverride([1.0], [2.0], [3.0], [4.0])}
     ),
     model_name="TEST OPENDSS MODEL 1",
     generator_config=GeneratorConfig(
@@ -1028,9 +1034,26 @@ get_paged_opendss_models_query = """
                         }
                         modulesConfiguration {
                             common {
+                                fixedTime{
+                                    loadTime
+                                    overrides {
+                                        loadId
+                                        loadWattsOverride
+                                        genWattsOverride
+                                        loadVarOverride
+                                        genVarOverride
+                                    }
+                                }
                                 timePeriod {
-                                    start
-                                    end
+                                    startTime
+                                    endTime
+                                    overrides {
+                                        loadId
+                                        loadWattsOverride
+                                        genWattsOverride
+                                        loadVarOverride
+                                        genVarOverride
+                                    }
                                 }
                             }
                             generator {


### PR DESCRIPTION
# Description

Remove the ability to specify time zone when running `run_opendss_export` and also adding the ability to specify load overrides in load time.

# Associated tasks

- https://github.com/zepben/evolve-app-server/pull/220

# Test Steps

Use `run_opendss_export` and `get_paged_opendss_models` methods.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- ~[ ] I have updated the changelog.~
not needed since no release happened since [this](https://github.com/zepben/eas-client-python/pull/30) was merged
- ~[ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

not breaking change.