### PR TITLE
[DEV 3366] Added support for load/gen vMinPu and vMaxPu values, and ctPrimScalingFactor

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,9 @@
 * `FixedTimeLoadOverride` now takes in optional list of floats instead of optional float for its variable.
 
 ### New Features
-* None.
+* Modification to `ModelConfig` to allow more customization for model generation
+  * Added support for separate `vMinPu` and `vMaxPu` with load and generators.
+  * Added support for `ctPrimScalingFactor` which is required when calculating new `ctPrim` value when feeder proxy loads are not in use.
 
 ### Enhancements
 * None.

--- a/src/zepben/eas/client/eas_client.py
+++ b/src/zepben/eas/client/eas_client.py
@@ -233,7 +233,7 @@ class EasClient:
                                         ]
                                     } if isinstance(config.load_time, TimePeriod) else None,
                                     "fixedTime": config.load_time and {
-                                        "loadTime": config.load_time.time.isoformat(),
+                                        "loadTime": config.load_time.load_time.isoformat(),
                                         "overrides": config.load_time.load_overrides and [
                                             {
                                                 "loadId": key,
@@ -259,7 +259,7 @@ class EasClient:
                                     for key, value in work_package.syf_config.load_time.load_overrides.items()}
                             } if isinstance(work_package.syf_config.load_time, TimePeriod) else None,
                             "fixedTime": work_package.syf_config.load_time and {
-                                "loadTime": work_package.syf_config.load_time.fetch_load_time.isoformat(),
+                                "loadTime": work_package.syf_config.load_time.load_time.isoformat(),
                                 "overrides": work_package.syf_config.load_time.load_overrides and {
                                     key: value.__dict__
                                     for key, value in work_package.syf_config.load_time.load_overrides.items()}
@@ -269,8 +269,10 @@ class EasClient:
                         "generatorConfig": work_package.generator_config and {
                             "model": work_package.generator_config.model and {
                                 "vmPu": work_package.generator_config.model.vm_pu,
-                                "vMinPu": work_package.generator_config.model.vmin_pu,
-                                "vMaxPu": work_package.generator_config.model.vmax_pu,
+                                "loadVMinPu": work_package.generator_config.model.load_vmin_pu,
+                                "loadVMaxPu": work_package.generator_config.model.load_vmax_pu,
+                                "genVMinPu": work_package.generator_config.model.gen_vmin_pu,
+                                "genVMaxPu": work_package.generator_config.model.gen_vmax_pu,
                                 "loadModel": work_package.generator_config.model.load_model,
                                 "collapseSWER": work_package.generator_config.model.collapse_swer,
                                 "calibration": work_package.generator_config.model.calibration,
@@ -319,6 +321,7 @@ class EasClient:
                                 "defaultLoadVar": work_package.generator_config.model.default_load_var,
                                 "defaultGenVar": work_package.generator_config.model.default_gen_var,
                                 "transformerTapSettings": work_package.generator_config.model.transformer_tap_settings,
+                                "ctPrimScalingFactor": work_package.generator_config.model.ct_prim_scaling_factor,
                             },
                             "solve": work_package.generator_config.solve and {
                                 "normVMinPu": work_package.generator_config.solve.norm_vmin_pu,
@@ -464,7 +467,7 @@ class EasClient:
                                         ]
                                     } if isinstance(config.load_time, TimePeriod) else None,
                                     "fixedTime": config.load_time and {
-                                        "loadTime": config.load_time.time.isoformat(),
+                                        "loadTime": config.load_time.load_time.isoformat(),
                                         "overrides": config.load_time.load_overrides and [
                                             {
                                                 "loadId": key,
@@ -490,7 +493,7 @@ class EasClient:
                                     for key, value in work_package.syf_config.load_time.load_overrides.items()}
                             } if isinstance(work_package.syf_config.load_time, TimePeriod) else None,
                             "fixedTime": work_package.syf_config.load_time and {
-                                "loadTime": work_package.syf_config.load_time.time.isoformat(),
+                                "loadTime": work_package.syf_config.load_time.load_time.isoformat(),
                                 "overrides": work_package.syf_config.load_time.load_overrides and {
                                     key: value.__dict__
                                     for key, value in work_package.syf_config.load_time.load_overrides.items()}
@@ -500,8 +503,8 @@ class EasClient:
                         "generatorConfig": work_package.generator_config and {
                             "model": work_package.generator_config.model and {
                                 "vmPu": work_package.generator_config.model.vm_pu,
-                                "vMinPu": work_package.generator_config.model.vmin_pu,
-                                "vMaxPu": work_package.generator_config.model.vmax_pu,
+                                "vMinPu": work_package.generator_config.model.load_vmin_pu,
+                                "vMaxPu": work_package.generator_config.model.load_vmax_pu,
                                 "loadModel": work_package.generator_config.model.load_model,
                                 "collapseSWER": work_package.generator_config.model.collapse_swer,
                                 "calibration": work_package.generator_config.model.calibration,
@@ -986,7 +989,7 @@ class EasClient:
                             },
                             "modulesConfiguration": {
                                 "common": {
-                                    **({ "loadTime": config.load_time.time.isoformat(),
+                                    **({ "loadTime": config.load_time.load_time.isoformat(),
                                           "overrides": config.load_time.load_overrides and [
                                                {
                                                    "loadId": key,
@@ -1014,8 +1017,8 @@ class EasClient:
                                 **({"generator": {
                                     **({"model": {
                                         "vmPu": config.generator_config.model.vm_pu,
-                                        "vMinPu": config.generator_config.model.vmin_pu,
-                                        "vMaxPu": config.generator_config.model.vmax_pu,
+                                        "vMinPu": config.generator_config.model.load_vmin_pu,
+                                        "vMaxPu": config.generator_config.model.load_vmax_pu,
                                         "loadModel": config.generator_config.model.load_model,
                                         "collapseSWER": config.generator_config.model.collapse_swer,
                                         "calibration": config.generator_config.model.calibration,

--- a/src/zepben/eas/client/work_package.py
+++ b/src/zepben/eas/client/work_package.py
@@ -145,8 +145,8 @@ class FixedTime:
     present for the provided time in the load database for accurate results.
     """
 
-    def __init__(self, time: datetime, load_overrides: Optional[Dict[str, FixedTimeLoadOverride]] = None):
-        self.time = time.replace(tzinfo=None)
+    def __init__(self, load_time: datetime, load_overrides: Optional[Dict[str, FixedTimeLoadOverride]] = None):
+        self.load_time = load_time.replace(tzinfo=None)
         self.load_overrides = load_overrides
 
 
@@ -212,17 +212,25 @@ class ModelConfig:
     vm_pu: Optional[float] = None
     """Voltage per-unit of voltage source."""
 
-    vmin_pu: Optional[float] = None
+    load_vmin_pu: Optional[float] = None
     """
-    Minimum per unit voltage for which the load model selected and generator model is assumed to apply. Below this value, the load/gen model reverts to a 
-    constant impedance model. For generator model used, this is used to determine the upper current limit. For example, if Vminpu is 0.90 then the current 
-    limit is (1/0.90) = 111%.
+    Minimum per unit voltage for which the load model selected is assumed to apply. Below this value, the load model reverts to a constant impedance model.
     """
 
-    vmax_pu: Optional[float] = None
+    load_vmax_pu: Optional[float] = None
     """
-    Maximum per unit voltage for which the load model selected and generator model is assumed to apply. Above this value, the load/gen model reverts to a 
-    constant impedance model.
+    Maximum per unit voltage for which the load model selected is assumed to apply. Above this value, the load model reverts to a constant impedance model.
+    """
+
+    gen_vmin_pu: Optional[float] = None
+    """
+    Minimum per unit voltage for which the generator model is assumed to apply. Below this value, the gen model reverts to a constant impedance model. 
+    For generator model used, this is used to determine the upper current limit. For example, if Vminpu is 0.90 then the current limit is (1/0.90) = 111%.
+    """
+
+    gen_vmax_pu: Optional[float] = None
+    """
+    Maximum per unit voltage for which the generator model is assumed to apply. Above this value, the gen model reverts to a constant impedance model.
     """
 
     load_model: Optional[int] = None
@@ -436,6 +444,11 @@ class ModelConfig:
     transformer_tap_settings: Optional[str] = None
     """
     The name of the set of distribution transformer tap settings to be applied to the model from an external source.
+    """
+
+    ct_prim_scaling_factor: Optional[float] = None
+    """
+    Optional setting for scaling factor of calculated CTPrim for zone sub transformers.
     """
 
 

--- a/test/test_eas_client.py
+++ b/test/test_eas_client.py
@@ -894,8 +894,10 @@ OPENDSS_CONFIG = OpenDssConfig(
     generator_config=GeneratorConfig(
         ModelConfig(
             vm_pu=1.0,
-            vmin_pu=0.80,
-            vmax_pu=1.15,
+            load_vmin_pu=0.80,
+            load_vmax_pu=1.15,
+            gen_vmin_pu=0.50,
+            gen_vmax_pu=2.00,
             load_model=1,
             collapse_swer=False,
             calibration=False,
@@ -944,7 +946,8 @@ OPENDSS_CONFIG = OpenDssConfig(
             default_gen_watts=[50.0, 150.0, 250.0],
             default_load_var=[10.0, 20.0, 30.0],
             default_gen_var=[5.0, 15.0, 25.0],
-            transformer_tap_settings="tap-3"
+            transformer_tap_settings="tap-3",
+            ct_prim_scaling_factor= 2.0
         ),
         SolveConfig(
             norm_vmin_pu=0.9,


### PR DESCRIPTION
# Description

Added support for load/gen vMinPu and vMaxPu values, and ctPrimScalingFactor.
There will be two PR chain to put these in but this PR should just be dependant of EAS.

# Associated tasks

EAS

# Test Steps

local spin up of EWB + EAS + Hosting capacity service and try to generate a model with run-hosting-capacity repo with local install of this branch.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

This will break all old configs for job running.