### PR TITLE
[DEV-9103] BESS sizing lookahead config

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@
   * get_paged_opendss_models
   * get_opendss_model
 * Most Input object will need to be migrated over to the new data model
+* For `InterventionConfigInput`, replaced `specificAllocationInstance` with `allocationInstanceSelection`, allowing multiple allocation instances to be selected.
 
 ### New Features
 * None.
@@ -28,6 +29,7 @@
 ### Enhancements
 * EasClient has new `query` and `mutation` methods that will accept `Query` and `Mutation` objects respectively.
   * Available queries and mutations can be found as `@classmethods` on `Queries` and `Mutations`.
+* Added `sizingLookaheadYears` to `CandidateGenerationConfigInput` for configuring community BESS candidate sizing lookahead.
 
 ### Fixes
 * Patched ariadne-codegen while waiting for release of dependent code.

--- a/src/zepben/eas/lib/generated_graphql_client/input_types.py
+++ b/src/zepben/eas/lib/generated_graphql_client/input_types.py
@@ -657,10 +657,10 @@ class InterventionConfigInput(BaseModel):
         alias="phaseRebalanceProportions", default=None
     )
     "The proportions to use for phase rebalancing. If this is unspecified and interventionType = PHASE_REBALANCING, phases will be rebalanced to equal proportions."
-    specific_allocation_instance: Optional[str] = Field(
-        alias="specificAllocationInstance", default=None
+    allocation_instance_selection: Optional[list[str]] = Field(
+        alias="allocationInstanceSelection", default=None
     )
-    "The specific instance of intervention to use for every allocation. If this is unspecified, all instances of the intervention class will be considered when choosing one for each candidate."
+    "The names of the instances of allocation to consider for this intervention. If unspecified, all valid instances of the specified intervention_type will be considered."
     year_range: Optional["YearRangeInput"] = Field(alias="yearRange", default=None)
     "The range of years to search for and apply interventions. All years within this range should be included in the work package. Defaults to 1AD to 9999AD."
 

--- a/src/zepben/eas/lib/generated_graphql_client/input_types.py
+++ b/src/zepben/eas/lib/generated_graphql_client/input_types.py
@@ -44,6 +44,10 @@ class CandidateGenerationConfigInput(BaseModel):
         alias="interventionCriteriaName", default=None
     )
     "The ID of the set of criteria used to select intervention candidates from enhanced metrics of the base work package run. Only used when `type` is `CRITERIA`."
+    sizing_lookahead_years: Optional[int] = Field(
+        alias="sizingLookaheadYears", default=0
+    )
+    "The number of years to look ahead from the first constraint violation when determining the size of each community BESS candidate. `None` means all years from the first constraint violation are considered. Only used when `type` is CRITERIA and `intervention_class` is COMMUNITY_BESS."
     tap_weighting_factor_lower_threshold: Optional[float] = Field(
         alias="tapWeightingFactorLowerThreshold", default=None
     )

--- a/test/test_eas_client.py
+++ b/test/test_eas_client.py
@@ -1293,11 +1293,40 @@ def test_work_package_config_to_json_includes_server_defaulted_fields_if_specifi
         "interventionType": "COMMUNITY_BESS",
         "candidateGeneration": None,
         "allocationCriteria": None,
-        "specificAllocationInstance": None,
+        "allocationInstanceSelection": None,
         "phaseRebalanceProportions": None,
         "dvms": None,
         "allocationLimitPerYear": 5
     }
+
+
+def test_work_package_config_to_json_includes_allocation_instance_selection_if_specified():
+    wp_config = WorkPackageInput(
+        feederConfigs=FeederConfigsInput(configs=[]),
+        intervention=InterventionConfigInput(
+            baseWorkPackageId="abc",
+            interventionType=InterventionClass.COMMUNITY_BESS,
+            allocationInstanceSelection=["bess-small", "bess-large"],
+            candidateGeneration=CandidateGenerationConfigInput(
+                type=CandidateGenerationType.CRITERIA,
+                interventionCriteriaName="community-bess-candidates",
+                sizingLookaheadYears=None
+            )
+        )
+    )
+    json_config = wp_config.model_dump_json(by_alias=True, exclude_defaults=True)
+
+    assert json.loads(json_config)['intervention'] == {
+        "baseWorkPackageId": "abc",
+        "interventionType": "COMMUNITY_BESS",
+        "candidateGeneration": {
+            "type": "CRITERIA",
+            "interventionCriteriaName": "community-bess-candidates",
+            "sizingLookaheadYears": None
+        },
+        "allocationInstanceSelection": ["bess-small", "bess-large"],
+    }
+
 
 def test_work_package_config_to_json_for_tap_optimization():
     wp_config = WorkPackageInput(
@@ -1334,6 +1363,7 @@ def test_work_package_config_to_json_for_tap_optimization():
             "candidateGeneration": {
                 "type": "TAP_OPTIMIZATION",
                 "interventionCriteriaName": None,
+                "sizingLookaheadYears": 0,
                 "averageVoltageSpreadThreshold": 40,
                 "voltageUnderLimitHoursThreshold": 1,
                 "voltageOverLimitHoursThreshold": 2,
@@ -1341,7 +1371,7 @@ def test_work_package_config_to_json_for_tap_optimization():
                 "tapWeightingFactorUpperThreshold": 0.4,
             },
             "allocationCriteria": None,
-            "specificAllocationInstance": None,
+            "allocationInstanceSelection": None,
             "phaseRebalanceProportions": None,
             "dvms": None,
             "allocationLimitPerYear": 5


### PR DESCRIPTION
# Description

Add support for new intervention config field `sizingLookaheadYears`, which determines how many years to look ahead when sizing community BESS.

Also changes

# Associated tasks

Tasks blocking this one:
- Accept field in graphql schema in EAS (PR TBA)

Tasks this is blocking:
- None

# Test Steps

Explain in detail how your reviewer can test the changes proposed in this PR. If it cannot be tested, leave an explanation on why.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [ ] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [ ] I have commented my code in any hard-to-understand or hacky areas.
- [ ] I have handled all new warnings generated by the compiler or IDE.
- [ ] I have rebased onto the target branch (usually main).

### Security
When developing applications, use following guidelines for information security considerations:
* Access to applications should be protected with security keys/tokens or usernames and passwords;
* All sessions are encrypted if possible;
* All application input is sanitised before being acted on (ie SQL statements, etc);
* Log messages, and especially client-facing ones, must be handled securely and must not leak credentials information (internal URLs, passwords, tokens).

- [ ] I have considered if this change impacts information security and made sure those impacts are handled.

### Documentation
- [ ] I have updated the changelog.
- [ ] I have updated any documentation required for these changes.

# Breaking Changes
- [ ] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

* For `InterventionConfigInput`, replaced `specificAllocationInstance` with `allocationInstanceSelection`, allowing multiple allocation instances to be selected.